### PR TITLE
Add client_max_body_size 0 in nginx conf, necessary for jenkins build

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,6 +10,7 @@ events {
 
 http {
     default_type  application/json;
+    client_max_body_size 0;
 
     server {
         listen 4550 default_server;


### PR DESCRIPTION
Hi, 

I propose you this quick PR about client_max_body_size option in Nginx conf. 

I use your image in my CI (Jenkins linked with sherpa to access my host docker daemon).

When I tried to build and push image, I've got an error "413 Request Entity Too Large" due to Ngninx.

With this update my build works, 

Maybe this PR is to simple, my Python is too old to propose you a PR where a new parameter can be use with docker run as --client_max_body_size (number or zero for unlimited), parse and injected in ngnix.conf.

Please tell me if you are ok with this PR, if not I will work to propose you a new one, write in Python for value injection in nginx.conf.

Regards, 

